### PR TITLE
remove +init /old PROJ usage from package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ addons:
 
 r_packages:
   - covr
+  - sp
+  - sf
+  - rgdal
 
 before_script:
   - echo "Revision:" $TRAVIS_COMMIT >> ./DESCRIPTION

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,4 +9,4 @@ Depends: R (>= 3.0.0)
 Description: Tools for working with Gustavo Niemeyer's geohash coordinate system, including API for interacting with other common R GIS libraries.
 URL: https://github.com/MichaelChirico/geohashTools
 License: MPL-2.0 | file LICENSE
-Suggests: rgdal, sf, sp, testthat
+Suggests: sf, sp, testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,4 +9,4 @@ Depends: R (>= 3.0.0)
 Description: Tools for working with Gustavo Niemeyer's geohash coordinate system, including API for interacting with other common R GIS libraries.
 URL: https://github.com/MichaelChirico/geohashTools
 License: MPL-2.0 | file LICENSE
-Suggests: sf, sp, testthat
+Suggests: rgdal, sf, sp, testthat

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
  1. `gh_decode` errors early on non-ASCII input to prevent out-of-memory access, [#19](https://github.com/MichaelChirico/geohashTools/issues/19).
  
- 2. Dependency upgrade of `r-spatial` to PROJ 6 revealed a test failure in `geohashTools` that has now been corrected, [#23](https://github.com/MichaelChirico/geohashTools/issues/23). Thanks @rsbivand for his diligence and proactivity in identifying the failure and to @Nowosad for providing helpful Docker images for testing.
+ 2. Dependency upgrade of `r-spatial` to PROJ 6 revealed a test failure in `geohashTools` that has now been corrected, [#23](https://github.com/MichaelChirico/geohashTools/issues/23). Thanks @rsbivand for his diligence and proactivity in identifying the failure, to @Nowosad for providing helpful Docker images for testing, and @mdsumner for helpful comments.
  
  3. Input with longitude< -180 (which should be wrapped again around the Earth) was calculated incorrectly, [#27](https://github.com/MichaelChirico/geohashTools/issues/27).
 

--- a/R/gis_tools.R
+++ b/R/gis_tools.R
@@ -1,5 +1,5 @@
 # https://epsg.io/4326
-wgs = as(sf::st_as_sf(obj, coords = c("lon", "lat"), crs = 4326L), "Spatial")
+wgs = as(sf::st_crs(4326L), 'CRS')
 
 # nocov start
 check_suggested = function(pkg) {

--- a/R/gis_tools.R
+++ b/R/gis_tools.R
@@ -1,5 +1,5 @@
 # https://epsg.io/4326
-wgs = function() sp::CRS('+init=epsg:4326')
+wgs = as(sf::st_as_sf(obj, coords = c("lon", "lat"), crs = 4326L), "Spatial")
 
 # nocov start
 check_suggested = function(pkg) {
@@ -26,7 +26,7 @@ gh_to_sp = function(geohashes) {
       latitude[ii] + c(-1, 1, 1, -1, -1) * delta_latitude[ii]
     ))), ID = gh[ii]))
     # gh_decode returns values in WSG 84
-  }), proj4string = wgs())
+  }), proj4string = wgs)
 }
 
 gh_to_spdf = function(...) {
@@ -82,7 +82,7 @@ gh_covering = function (SP, precision = 6L, minimal = FALSE)
     latitude = seq(bb[2L, 'min'], bb[2L, 'max'] + delta[1L], by = delta[1L]),
     longitude = seq(bb[1L, 'min'], bb[1L, 'max'] + delta[2L], by = delta[2L])
   ), gh_encode(latitude, longitude, precision))
-  if (is.na(prj4 <- sp::proj4string(SP))) sp::proj4string(SP) = (prj4 <- wgs())
+  if (is.na(prj4 <- sp::proj4string(SP))) sp::proj4string(SP) = (prj4 <- wgs)
   cover = sp::spTransform(gh_to_spdf(gh), prj4)
   if (minimal) {
     # slightly more efficient to use rgeos, but there's a bug preventing

--- a/R/gis_tools.R
+++ b/R/gis_tools.R
@@ -1,5 +1,5 @@
 # https://epsg.io/4326
-wgs = as(sf::st_crs(4326L), 'CRS')
+wgs = sp::CRS("+proj=longlat +datum=WGS84", doCheckCRSArgs = FALSE)
 
 # nocov start
 check_suggested = function(pkg) {

--- a/R/gis_tools.R
+++ b/R/gis_tools.R
@@ -1,5 +1,5 @@
 # https://epsg.io/4326
-wgs = sp::CRS("+proj=longlat +datum=WGS84", doCheckCRSArgs = FALSE)
+wgs = function() sp::CRS("+proj=longlat +datum=WGS84", doCheckCRSArgs = FALSE)
 
 # nocov start
 check_suggested = function(pkg) {
@@ -26,7 +26,7 @@ gh_to_sp = function(geohashes) {
       latitude[ii] + c(-1, 1, 1, -1, -1) * delta_latitude[ii]
     ))), ID = gh[ii]))
     # gh_decode returns values in WSG 84
-  }), proj4string = wgs)
+  }), proj4string = wgs())
 }
 
 gh_to_spdf = function(...) {
@@ -82,7 +82,7 @@ gh_covering = function (SP, precision = 6L, minimal = FALSE)
     latitude = seq(bb[2L, 'min'], bb[2L, 'max'] + delta[1L], by = delta[1L]),
     longitude = seq(bb[1L, 'min'], bb[1L, 'max'] + delta[2L], by = delta[2L])
   ), gh_encode(latitude, longitude, precision))
-  if (is.na(prj4 <- sp::proj4string(SP))) sp::proj4string(SP) = (prj4 <- wgs)
+  if (is.na(prj4 <- sp::proj4string(SP))) sp::proj4string(SP) = (prj4 <- wgs())
   cover = sp::spTransform(gh_to_spdf(gh), prj4)
   if (minimal) {
     # slightly more efficient to use rgeos, but there's a bug preventing

--- a/tests/testthat/test-gis-tools.R
+++ b/tests/testthat/test-gis-tools.R
@@ -139,10 +139,7 @@ test_that('gh_covering works', {
   sp::proj4string(banjarmasin) = NA_character_
   banjarmasin_cover = gh_covering(banjarmasin, minimal = TRUE)
   sp::proj4string(banjarmasin_cover) = wgs
-  expect_true(sp::identicalCRS(banjarmasin_tight, banjarmasin_cover))
-  banjarmasin_cover = sp::spTransform(banjarmasin_cover, sp::proj4string(banjarmasin_tight))
-  banjarmasin_tight = sp::spTransform(banjarmasin_tight, sp::proj4string(banjarmasin_tight))
-  expect_identical(banjarmasin_tight, banjarmasin_cover)
+  expect_equivalent(banjarmasin_cover, banjarmasin_tight)
 
   # errors
   expect_error(gh_covering(4L), 'Object to cover must be Spatial', fixed = TRUE)

--- a/tests/testthat/test-gis-tools.R
+++ b/tests/testthat/test-gis-tools.R
@@ -109,6 +109,7 @@ test_that('gh_to_sf works', {
 
 test_that('gh_covering works', {
   skip_if(!requireNamespace('sp'), "sp installation required")
+  skip_if(!requireNamespace('rgdal'), "rgdal installation required")
   banjarmasin = sp::SpatialPoints(cbind(
     c(114.605, 114.5716, 114.627, 114.5922, 114.6321,
       114.5804, 114.6046, 114.6028, 114.6232, 114.5792),
@@ -150,6 +151,7 @@ test_that('gh_covering works', {
 test_that('gh_covering_sf works', {
   skip_if(!requireNamespace('sp'), "sp installation required")
   skip_if(!requireNamespace('sf'), "sp installation required")
+  skip_if(!requireNamespace('rgdal'), "rgdal installation required")
   banjarmasin = sf::st_as_sf(sp::SpatialPoints(cbind(
     c(114.605, 114.5716, 114.627, 114.5922, 114.6321,
       114.5804, 114.6046, 114.6028, 114.6232, 114.5792),

--- a/tests/testthat/test-gis-tools.R
+++ b/tests/testthat/test-gis-tools.R
@@ -136,10 +136,9 @@ test_that('gh_covering works', {
   expect_length(banjarmasin_tight, 10L)
   # #13 -- proj4string<- doesn't mutate object, but proj4string() <- does?
   sp::proj4string(banjarmasin) = NA_character_
-  expect_identical(
-    banjarmasin_tight,
-    sp::`proj4string<-`(gh_covering(banjarmasin, minimal = TRUE), wgs)
-  )
+  banjarmasin_covering = gh_covering(banjarmasin, minimal = TRUE)
+  sp::proj4string(banjarmasin_covering) = wgs
+  expect_identical(banjarmasin_tight, banjarmasin_covering)
 
   # errors
   expect_error(gh_covering(4L), 'Object to cover must be Spatial', fixed = TRUE)

--- a/tests/testthat/test-gis-tools.R
+++ b/tests/testthat/test-gis-tools.R
@@ -115,7 +115,7 @@ test_that('gh_covering works', {
 
   # core
   banjarmasin_cover = gh_covering(banjarmasin)
-  wgs = as(sf::st_crs(4326L), 'CRS')
+  wgs = sp::CRS("+proj=longlat +datum=WGS84", doCheckCRSArgs = FALSE)
   sp::proj4string(banjarmasin) = wgs
   # use gUnaryUnion to overcome rgeos bug as reported 2019-08-16
   expect_true(!any(is.na(sp::over(banjarmasin, banjarmasin_cover))))

--- a/tests/testthat/test-gis-tools.R
+++ b/tests/testthat/test-gis-tools.R
@@ -115,7 +115,7 @@ test_that('gh_covering works', {
 
   # core
   banjarmasin_cover = gh_covering(banjarmasin)
-  wgs = as(sf::st_as_sf(obj, coords = c("lon", "lat"), crs = 4326L), "Spatial")
+  wgs = as(sf::st_crs(4326L), 'CRS')
   sp::proj4string(banjarmasin) = wgs
   # use gUnaryUnion to overcome rgeos bug as reported 2019-08-16
   expect_true(!any(is.na(sp::over(banjarmasin, banjarmasin_cover))))

--- a/tests/testthat/test-gis-tools.R
+++ b/tests/testthat/test-gis-tools.R
@@ -136,9 +136,12 @@ test_that('gh_covering works', {
   expect_length(banjarmasin_tight, 10L)
   # #13 -- proj4string<- doesn't mutate object, but proj4string() <- does?
   sp::proj4string(banjarmasin) = NA_character_
-  banjarmasin_covering = gh_covering(banjarmasin, minimal = TRUE)
-  sp::proj4string(banjarmasin_covering) = wgs
-  expect_identical(banjarmasin_tight, banjarmasin_covering)
+  banjarmasin_cover = gh_covering(banjarmasin, minimal = TRUE)
+  sp::proj4string(banjarmasin_cover) = wgs
+  expect_true(sp::identicalCRS(banjarmasin_tight, banjarmasin_cover))
+  banjarmasin_cover = sp::spTransform(banjarmasin_cover, sp::proj4string(banjarmasin_tight))
+  banjarmasin_tight = sp::spTransform(banjarmasin_tight, sp::proj4string(banjarmasin_tight))
+  expect_identical(banjarmasin_tight, banjarmasin_cover)
 
   # errors
   expect_error(gh_covering(4L), 'Object to cover must be Spatial', fixed = TRUE)

--- a/tests/testthat/test-gis-tools.R
+++ b/tests/testthat/test-gis-tools.R
@@ -15,7 +15,8 @@ test_that('gh_to_sp works', {
                         57.3046875, -20.390625, -20.21484375,
                         -20.21484375, -20.390625, -20.390625),
                       nrow = 5L, ncol = 2L))
-  expect_equal(ghSP@proj4string, sp::CRS("+init=epsg:4326"))
+  wgs = sp::CRS("+proj=longlat +datum=WGS84", doCheckCRSArgs = FALSE)
+  expect_equal(ghSP@proj4string, wgs)
 
   # duplicate inputs dropped
   expect_warning(ghSP2 <- gh_to_sp(rep(mauritius, 2L)),
@@ -38,7 +39,8 @@ test_that('gh_to_spdf.default works', {
                         87.890625, 87.5390625, 43.59375, 43.76953125,
                         43.76953125, 43.59375, 43.59375),
                       nrow = 5L, ncol = 2L))
-  expect_equal(ghSPDF@proj4string, sp::CRS("+init=epsg:4326"))
+  wgs = sp::CRS("+proj=longlat +datum=WGS84", doCheckCRSArgs = FALSE)
+  expect_equal(ghSPDF@proj4string, wgs)
 
   DF = data.frame(ID = 1:9, row.names = urumqi)
   expect_equal(ghSPDF@data, DF)
@@ -66,7 +68,8 @@ test_that('gh_to_spdf.data.frame works', {
                         87.890625, 87.5390625, 43.59375, 43.76953125,
                         43.76953125, 43.59375, 43.59375),
                       nrow = 5L, ncol = 2L))
-  expect_equal(ghSPDF@proj4string, sp::CRS("+init=epsg:4326"))
+  wgs = sp::CRS("+proj=longlat +datum=WGS84", doCheckCRSArgs = FALSE)
+  expect_equal(ghSPDF@proj4string, wgs)
   expect_equal(ghSPDF@data, DF)
 
   # duplicated inputs (#8)

--- a/tests/testthat/test-gis-tools.R
+++ b/tests/testthat/test-gis-tools.R
@@ -115,7 +115,7 @@ test_that('gh_covering works', {
 
   # core
   banjarmasin_cover = gh_covering(banjarmasin)
-  wgs = sp::CRS("+init=epsg:4326")
+  wgs = as(sf::st_as_sf(obj, coords = c("lon", "lat"), crs = 4326L), "Spatial")
   sp::proj4string(banjarmasin) = wgs
   # use gUnaryUnion to overcome rgeos bug as reported 2019-08-16
   expect_true(!any(is.na(sp::over(banjarmasin, banjarmasin_cover))))


### PR DESCRIPTION
 With these changes I now pass tests on `jakubnowosad/geocompr_proj6`

@rsbivand would you mind having a quick look if the changes make sense?

In particular I find this awkward:

```
  banjarmasin_cover = gh_covering(banjarmasin, minimal = TRUE)
  sp::proj4string(banjarmasin_cover) = wgs
  expect_true(sp::identicalCRS(banjarmasin_tight, banjarmasin_cover))
  banjarmasin_cover = sp::spTransform(banjarmasin_cover, sp::proj4string(banjarmasin_tight))
  banjarmasin_tight = sp::spTransform(banjarmasin_tight, sp::proj4string(banjarmasin_tight))
  expect_identical(banjarmasin_tight, banjarmasin_cover)
```

I have to transform both polygons into an identical CRS in order for them to show up as "identical" according to `testthat`. Is there any "smarter" way to do polygon comparison?