### PR TITLE
gh_cover works for SpatialPointsDataFrame

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # `geohashTools` NEWS
 
+## v0.3.2
+
+### NEW FEATURES
+
+### BUG FIXES
+
+ 1. `gh_covering` would fail with `minimal=TRUE` for `SpatialPointsDataFrame` input, [#30](https://github.com/MichaelChirico/geohashTools/issues/30). Thanks @dshkol for the report and working example.
+
+### NOTES
+
 ## v0.3.1
 
 ### NEW FEATURES

--- a/R/gis_tools.R
+++ b/R/gis_tools.R
@@ -88,7 +88,8 @@ gh_covering = function (SP, precision = 6L, minimal = FALSE)
     # slightly more efficient to use rgeos, but there's a bug preventing
     #   that version from working (reported 2019-08-16):
     #   cover[c(rgeos::gIntersects(cover, SP, byid = c(TRUE, FALSE))), ]
-    cover = cover[!drop(is.na(sp::over(cover, SP))), ]
+    cover = cover[which(sapply(sp::over(cover, SP, returnList=TRUE), NROW) > 0L), ]
+    sp::proj4string(cover) = prj4
   }
   return(if (sf_input) sf::st_as_sf(cover) else cover)
 }

--- a/tests/testthat/test-gis-tools.R
+++ b/tests/testthat/test-gis-tools.R
@@ -108,8 +108,8 @@ test_that('gh_to_sf works', {
 })
 
 test_that('gh_covering works', {
-  skip_if(!requireNamespace('sp'), "sp installation required")
-  skip_if(!requireNamespace('rgdal'), "rgdal installation required")
+  skip_if_not(requireNamespace('sp'), "sp installation required")
+  skip_if_not(requireNamespace('rgdal'), "rgdal installation required")
   banjarmasin = sp::SpatialPoints(cbind(
     c(114.605, 114.5716, 114.627, 114.5922, 114.6321,
       114.5804, 114.6046, 114.6028, 114.6232, 114.5792),
@@ -140,6 +140,12 @@ test_that('gh_covering works', {
   banjarmasin_cover = gh_covering(banjarmasin, minimal = TRUE)
   sp::proj4string(banjarmasin_cover) = wgs
   expect_equivalent(banjarmasin_cover, banjarmasin_tight)
+
+  # works for SpatialPointsDataFrame when minimal=TRUE, #30
+  banjarmasinDF = sp::SpatialPointsDataFrame(
+    banjarmasin, data = data.frame(ID = letters[seq_along(banjarmasin)])
+  )
+  expect_equal(gh_covering(banjarmasinDF, minimal=TRUE)@polygons, banjarmasin_tight@polygons)
 
   # errors
   expect_error(gh_covering(4L), 'Object to cover must be Spatial', fixed = TRUE)


### PR DESCRIPTION
Closes #30 

cc @dshkol -- hopefully becomes easier when migrating away from `sp`