### PR TITLE
Vectorized precision in gh_encode + doc/build cleanups

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,6 +13,9 @@
 ^\.travis\.yml$
 ^\.lintr$
 
+# editor / tooling
+^\.claude$
+
 ^logo_maker.R$
 ^_pkgdown\.yml$
 ^docs$

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,12 +6,6 @@
 
  1. `gh_encode` accepts a vector of `precision` values (the same length as the input coordinates), so different coordinates can be encoded at different zoom levels in a single call. A single `precision` value still applies to all coordinates as before.
 
-### NOTES
-
- 1. Documentation for `gh_encode` corrected to state the actual maximum precision (25, not 28).
-
- 2. Added `.claude` to `.Rbuildignore` to silence a "hidden files and directories" `NOTE` from `R CMD check`.
-
 ## v0.3.3
 
 Drop references to deprecated rgdal.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # `geohashTools` NEWS
 
+## v0.3.4 (Development)
+
+### NEW FEATURES
+
+ 1. `gh_encode` accepts a vector of `precision` values (the same length as the input coordinates), so different coordinates can be encoded at different zoom levels in a single call. A single `precision` value still applies to all coordinates as before.
+
+### NOTES
+
+ 1. Documentation for `gh_encode` corrected to state the actual maximum precision (25, not 28).
+
+ 2. Added `.claude` to `.Rbuildignore` to silence a "hidden files and directories" `NOTE` from `R CMD check`.
+
 ## v0.3.3
 
 Drop references to deprecated rgdal.

--- a/R/gh_encode.R
+++ b/R/gh_encode.R
@@ -1,11 +1,13 @@
 gh_encode = function(latitude, longitude, precision = 6L) {
-  if (length(precision) != 1L)
-    stop('More than one precision value detected; precision is fixed on input (for now)')
-  if (precision < 1L)
+  n = length(latitude)
+  np = length(precision)
+  if (np != 1L && np != n)
+    stop('precision must be length 1 or the same length as the coordinates (got ', np, ' for ', n, ' coordinates)')
+  if (anyNA(precision) || any(precision < 1L))
     stop('Invalid precision. Precision is measured in number of characters, must be at least 1.')
-  if (precision > .global$GH_MAX_PRECISION) {
+  if (any(precision > .global$GH_MAX_PRECISION)) {
     warning('Precision is limited to ', .global$GH_MAX_PRECISION, ' characters; truncating')
-    precision = .global$GH_MAX_PRECISION
+    precision = pmin(precision, .global$GH_MAX_PRECISION)
   }
 
   .Call(Cgh_encode, latitude, longitude, as.integer(precision))

--- a/man/gh_encode.Rd
+++ b/man/gh_encode.Rd
@@ -13,10 +13,10 @@ gh_encode(latitude, longitude, precision = 6L)
 \arguments{
   \item{latitude}{ \code{numeric} vector of input latitude (y) coordinates. Must be in \code{[-90, 90)}. }
   \item{longitude}{ \code{numeric} vector of input longitude (x) coordinates. Should be in \code{[-180, 180)}. }
-  \item{precision}{ Positive \code{integer} scalar controlling the 'zoom level' -- how many characters should be used in the output. }
+  \item{precision}{ Positive \code{integer} controlling the 'zoom level' -- how many characters should be used in the output. Either a single value applied to all coordinates, or a vector the same length as \code{latitude}/\code{longitude} giving a per-coordinate precision. }
 }
 \details{
-  \code{precision} is limited to at most 28. This level of precision encodes locations on the globe at a nanometer scale and is already more than enough for basically all applications.
+  \code{precision} is limited to at most 25. This level of precision encodes locations on the globe at a nanometer scale and is already more than enough for basically all applications.
 
   Longitudes outside \code{[-180, 180)} will be wrapped appropriately to the standard longitude grid.
 }
@@ -37,4 +37,7 @@ gh_encode(2.345, 6.789)
 # geohashes are left-closed, right-open, so boundary coordinates are
 #   associated to the east and/or north
 gh_encode(0, 0)
+
+# precision can vary by coordinate
+gh_encode(c(2.345, 0), c(6.789, 0), precision = c(4L, 8L))
 }

--- a/src/encode.c
+++ b/src/encode.c
@@ -6,12 +6,12 @@ SEXP gh_encode(SEXP y, SEXP x, SEXP k_arg) {
   if (LENGTH(x) != n)
     error("Inputs must be the same size.");
   // precision is either a single value (recycled) or one value per coordinate
-  int nk = LENGTH(k_arg);
-  const int *kp = INTEGER(k_arg);
+  const int nk = LENGTH(k_arg);
+  const int *kp = INTEGER_RO(k_arg);
   // size the working buffer to the largest requested precision
   int kmax = 0;
   for (int j=0; j<nk; j++) if (kp[j] > kmax) kmax = kp[j];
-  char gh_elt[kmax+1];
+  char *gh_elt = (char *) R_alloc(kmax + 1, sizeof(char));
 
   int nprotect = 0;
   SEXP gh = PROTECT(allocVector(STRSXP, n)); nprotect++;

--- a/src/encode.c
+++ b/src/encode.c
@@ -5,9 +5,15 @@ SEXP gh_encode(SEXP y, SEXP x, SEXP k_arg) {
   int n = LENGTH(y);
   if (LENGTH(x) != n)
     error("Inputs must be the same size.");
-  int k = INTEGER(k_arg)[0];
-  char gh_elt[k+1];
-  gh_elt[k]='\0';
+  // precision is either a single value (recycled) or one value per coordinate
+  int nk = LENGTH(k_arg);
+  if (nk != 1 && nk != n)
+    error("precision must be length 1 or the same length as the coordinates.");
+  const int *kp = INTEGER(k_arg);
+  // size the working buffer to the largest requested precision
+  int kmax = 0;
+  for (int j=0; j<nk; j++) if (kp[j] > kmax) kmax = kp[j];
+  char gh_elt[kmax+1];
 
   int nprotect = 0;
   SEXP gh = PROTECT(allocVector(STRSXP, n)); nprotect++;
@@ -37,6 +43,8 @@ SEXP gh_encode(SEXP y, SEXP x, SEXP k_arg) {
   } zx, zy;
   int xidx, yidx; // which cell did we land in?
   for (int i=0; i<n; i++) {
+    int k = kp[nk == 1 ? 0 : i]; // this coordinate's precision
+    gh_elt[k] = '\0';
     if (!R_FINITE(xp[i]) || !R_FINITE(yp[i])) {
       SET_STRING_ELT(gh, i, NA_STRING);
       continue;

--- a/src/encode.c
+++ b/src/encode.c
@@ -7,8 +7,6 @@ SEXP gh_encode(SEXP y, SEXP x, SEXP k_arg) {
     error("Inputs must be the same size.");
   // precision is either a single value (recycled) or one value per coordinate
   int nk = LENGTH(k_arg);
-  if (nk != 1 && nk != n)
-    error("precision must be length 1 or the same length as the coordinates.");
   const int *kp = INTEGER(k_arg);
   // size the working buffer to the largest requested precision
   int kmax = 0;

--- a/tests/testthat/test-encode.R
+++ b/tests/testthat/test-encode.R
@@ -69,7 +69,7 @@ test_that('geohash encoder works', {
   )
   expect_error(
     gh_encode(y, x, c(5L, 6L)),
-    'More than one precision value',
+    'precision must be length 1 or the same length as the coordinates',
     fixed = TRUE
   )
   expect_error(
@@ -100,4 +100,62 @@ test_that('geohash encoder works', {
 
   # stress testing
   expect_identical(gh_encode(numeric(), numeric()), character())
+})
+
+test_that('gh_encode accepts a vector of precisions', {
+  set.seed(4080L)
+  lat = runif(8L, -80.0, 80.0)
+  lon = runif(8L, -170.0, 170.0)
+  precision = 1:8
+
+  vec = gh_encode(lat, lon, precision)
+
+  # equivalent to encoding each coordinate at its own precision
+  elementwise = vapply(
+    seq_along(lat),
+    function(i) gh_encode(lat[i], lon[i], precision[i]),
+    character(1L)
+  )
+  expect_identical(vec, elementwise)
+
+  # each result is the length-`precision` prefix of the full-precision encode
+  full = gh_encode(lat, lon, max(precision))
+  expect_identical(vec, substr(full, 1L, precision))
+
+  # length-1 precision still recycles (unchanged behaviour)
+  expect_identical(gh_encode(lat, lon, 6L), substr(full, 1L, 6L))
+
+  # NA / infinite coordinates remain NA even with per-element precision
+  expect_identical(
+    gh_encode(c(0.1234, NA, Inf), c(5.6789, 1.0, 2.0), c(6L, 5L, 4L)),
+    c('s0h09n', NA_character_, NA_character_)
+  )
+
+  # per-element truncation past the maximum precision
+  expect_warning(
+    expect_identical(
+      gh_encode(c(0.1234, 0.1234), c(5.6789, 5.6789), c(6L, 30L)),
+      c('s0h09n', substring('s0h09nrnzgqv8je0f4jpd0000', 1L, 25L))
+    ),
+    'Precision is limited',
+    fixed = TRUE
+  )
+
+  # invalid per-element precision
+  expect_error(
+    gh_encode(lat, lon, c(1:7, 0L)),
+    'Precision is measured',
+    fixed = TRUE
+  )
+  expect_error(
+    gh_encode(lat, lon, c(1:7, NA_integer_)),
+    'Precision is measured',
+    fixed = TRUE
+  )
+  # wrong-length precision (neither 1 nor length(coords))
+  expect_error(
+    gh_encode(lat, lon, 1:3),
+    'precision must be length 1 or the same length as the coordinates',
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-encode.R
+++ b/tests/testthat/test-encode.R
@@ -103,7 +103,7 @@ test_that('geohash encoder works', {
 })
 
 test_that('gh_encode accepts a vector of precisions', {
-  set.seed(4080L)
+  withr::local_seed(4080L)
   lat = runif(8L, -80.0, 80.0)
   lon = runif(8L, -170.0, 170.0)
   precision = 1:8
@@ -121,9 +121,6 @@ test_that('gh_encode accepts a vector of precisions', {
   # each result is the length-`precision` prefix of the full-precision encode
   full = gh_encode(lat, lon, max(precision))
   expect_identical(vec, substr(full, 1L, precision))
-
-  # length-1 precision still recycles (unchanged behaviour)
-  expect_identical(gh_encode(lat, lon, 6L), substr(full, 1L, 6L))
 
   # NA / infinite coordinates remain NA even with per-element precision
   expect_identical(


### PR DESCRIPTION
QOL improvements (independent of the `gh_covering` performance work in #44).

## `gh_encode()` accepts a vector of precisions

`gh_encode()` previously errored on any `precision` of length > 1 (`"precision is fixed on input (for now)"`). It now accepts either:
- a single `precision` (applied to all coordinates, as before), or
- a `precision` vector the same length as the coordinates, giving a per-coordinate zoom level.

```r
gh_encode(c(2.345, 0), c(6.789, 0), precision = c(4L, 8L))
#> [1] "s0kv"     "s0000000"
```

Backward compatible — length-1 precision behaves exactly as before. The C encoder sizes its working buffer to the largest requested precision and reads each coordinate's precision inside the main loop. New tests verify the vector path equals element-wise scalar calls, prefix behaviour, `NA`/`Inf` handling, per-element truncation warnings, and the length/validity error paths.

## Doc & build cleanups
- **Doc fix:** `?gh_encode` claimed a maximum precision of 28; the actual cap is 25 (`GH_MAX_PRECISION`). Corrected.
- **Build:** added `.claude` to `.Rbuildignore` to silence the `R CMD check` "hidden files and directories" `NOTE`.

## Notes
- The package's `man/*.Rd` are hand-maintained (not roxygen-generated), so `RoxygenNote: 7.2.3` in `DESCRIPTION` is vestigial — bumping it would falsely imply roxygen manages the docs. Left as-is; flagging in case you'd prefer to remove the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)